### PR TITLE
Replace while loop with byte_string multiplication

### DIFF
--- a/simplepadding/__init__.py
+++ b/simplepadding/__init__.py
@@ -39,8 +39,6 @@ def encode(payload, target_length):
 
     length_header = struct.pack('!L', len(payload))
 
-    padding_footer = b''
-    while len(padding_footer) < (target_length - no_padding_length):
-        padding_footer += b'P'
+    padding_footer = b'P' * (target_length - no_padding_length)
 
     return length_header + payload + padding_footer


### PR DESCRIPTION
Using byte_string multiplication here is much more efficient and the while loop is completely unnecessary because the number of padding bytes needed is fully determined by `target_length - no_padding_length`.

On a quick test using a `target_length` of 1024 and a `no_padding_length` of 93 averaged over 10000 runs, this one line ran 625.119 times faster than the while loop it replaces. Those speedups scale massively. For instance, with 32768 and 382 inputs over 5000 tests, the new line is 15209.175 times faster.

Also note that if no padding is needed, `b'P' * 0 = b''` so the behavior of the code in this case is unchanged.

---

test code:

```python
def run_orig(target_length, no_padding_length):
    ts = perf_counter()
    padding_footer = b''
    while len(padding_footer) < (target_length - no_padding_length):
        padding_footer += b'P'
    te = perf_counter()
    return (te - ts)

def run_new(target_length, no_padding_length):
    ts = perf_counter()
    padding_footer = b'P' * (target_length - no_padding_length)
    te = perf_counter()
    return (te - ts)

def calc_speedup(target_length, no_padding_length, num_tests):
    orig_avg = 0.0
    new_avg = 0.0
    for i in range(num_tests):
        orig_avg += run_orig(target_length, no_padding_length)
        new_avg += run_new(target_length, no_padding_length)
    orig_avg /= num_tests
    new_avg /= num_tests
    speedup = orig_avg / new_avg
    return (orig_avg, new_avg, speedup)
```