### PR TITLE
Use full version for scorecard action.

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@v1
+        uses: ossf/scorecard-action@v1.1.2
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Apparently they don't expose the short version numbers: https://github.com/brave/simplepadding/actions/runs/2743178273