### PR TITLE
Update pylint package name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install linters
-        run: sudo apt-get install -y pyflakes3 pycodestyle pydocstyle codespell pylint3
+        run: sudo apt-get install -y pyflakes3 pycodestyle pydocstyle codespell pylint
 
       - name: Run tests
         run: make test

--- a/pad
+++ b/pad
@@ -54,7 +54,7 @@ def main():  # pylint: disable=missing-docstring
     parser.add_argument('-d', '--decode', const='decode', action='store_const',
                         help="remove padding instead of adding it.")
     parser.add_argument('-V', '--version', action='version',
-                        version='pad %s' % VERSION)
+                        version=f'pad {VERSION}')
     args = parser.parse_args()
 
     if not args.decode and args.length <= 0:


### PR DESCRIPTION
The `pylint3` package was renamed to `pylint` in recent Ubuntu releases.